### PR TITLE
feat: spago packages -> extract overrides

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -6,7 +6,7 @@ let overrides = {=}
 let additions = {=}
 
 in      upstream
-    //  https://raw.githubusercontent.com/srghma/dotfiles/master/spago/packages.dhall sha256:da57a54570c83b3d6ba32782ef80ddcf26237361d5d83bfeb8734cc1cd1c3d30
+    //  https://raw.githubusercontent.com/srghma/dotfiles/master/spago/packages.dhall sha256:6d1a867eb821ae07fea3021b3df23c083c30137d644767e271503c32aa460fd4
           upstream.(https://raw.githubusercontent.com/srghma/dotfiles/master/spago/upstreamTypeChunk.dhall sha256:1f07f2737ec9a052fa448d4f2c3058ed5bb68ea66622ac3d1f74bd78eeeac09b)
     //  overrides
     //  additions

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,113 +1,12 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200716/packages.dhall sha256:c4683b4c4da0fd33e0df86fc24af035c059270dd245f68b79a7937098f6c6542
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200831/packages.dhall sha256:cdb3529cac2cd8dd780f07c80fd907d5faceae7decfcaa11a12037df68812c83
 
-let overrides =
-      { argonaut-core =
-              upstream.argonaut-core
-          //  { repo = "https://github.com/srghma/purescript-argonaut-core.git"
-              , version = "master"
-              }
-      , either =
-              upstream.either
-          //  { repo = "https://github.com/srghma/purescript-either.git"
-              , version = "patch-1"
-              }
-      }
+let overrides = {=}
 
-let additions =
-      { mkdirp-aff =
-        { dependencies =
-          [ "prelude"
-          , "effect"
-          , "node-fs-aff"
-          , "node-fs"
-          , "node-path"
-          , "either"
-          , "exceptions"
-          , "aff"
-          ]
-        , repo = "https://github.com/leighman/purescript-mkdirp-aff.git"
-        , version = "master"
-        }
-      , protolude =
-        { dependencies =
-          [ "affjax"
-          , "console"
-          , "effect"
-          , "node-fs-aff"
-          , "node-process"
-          , "node-path"
-          , "prelude"
-          , "proxy"
-          , "psci-support"
-          , "record"
-          , "typelevel-prelude"
-          , "debug"
-          , "variant"
-          , "ansi"
-          , "generics-rep"
-          ]
-        , repo = "https://github.com/srghma/purescript-protolude.git"
-        , version = "master"
-        }
-      , ps-cst =
-        { dependencies =
-          [ "console"
-          , "effect"
-          , "generics-rep"
-          , "psci-support"
-          , "record"
-          , "strings"
-          , "spec"
-          , "node-path"
-          , "node-fs-aff"
-          , "ansi"
-          , "dodo-printer"
-          ]
-        , repo = "https://github.com/srghma/purescript-ps-cst.git"
-        , version = "master"
-        }
-      , dodo-printer =
-        { dependencies =
-          [ "aff"
-          , "ansi"
-          , "avar"
-          , "console"
-          , "effect"
-          , "foldable-traversable"
-          , "lists"
-          , "maybe"
-          , "minibench"
-          , "node-child-process"
-          , "node-fs-aff"
-          , "node-process"
-          , "psci-support"
-          , "strings"
-          ]
-        , repo = "https://github.com/natefaubion/purescript-dodo-printer.git"
-        , version = "master"
-        }
-      , homogeneous-records =
-        { dependencies =
-          [ "record", "prelude", "typelevel-prelude", "unfoldable", "control" ]
-        , repo = "https://github.com/srghma/purescript-homogeneous-records.git"
-        , version = "master"
-        }
-      , unordered-collection =
-        { dependencies =
-          [ "enums"
-          , "functions"
-          , "integers"
-          , "lists"
-          , "prelude"
-          , "record"
-          , "tuples"
-          , "typelevel-prelude"
-          ]
-        , repo =
-            "https://github.com/fehrenbach/purescript-unordered-collections.git"
-        , version = "master"
-        }
-      }
+let additions = {=}
 
-in  upstream // overrides // additions
+in      upstream
+    //  https://raw.githubusercontent.com/srghma/dotfiles/master/spago/packages.dhall sha256:da57a54570c83b3d6ba32782ef80ddcf26237361d5d83bfeb8734cc1cd1c3d30
+          upstream.(https://raw.githubusercontent.com/srghma/dotfiles/master/spago/upstreamTypeChunk.dhall sha256:1f07f2737ec9a052fa448d4f2c3058ed5bb68ea66622ac3d1f74bd78eeeac09b)
+    //  overrides
+    //  additions

--- a/src/GraphqlClient/HTTP.purs
+++ b/src/GraphqlClient/HTTP.purs
@@ -84,7 +84,7 @@ printGraphqlError = case _ of
   GraphqlUnexpectedPayloadError error jsonBody -> intercalate "\n"
     [ "Unexpected payload:"
     , "  error = " <> printJsonDecodeError error
-    , "  body = " <> ArgonautCore.stringifyWithSpace 2 jsonBody
+    , "  body = " <> ArgonautCore.stringifyWithIndent 2 jsonBody
     ]
   GraphqlUserError errorsArray possiblyParsedData ->
     let errorsArray' = errorsArray <#> unwrap <#> _.message <#> ("  " <> _)


### PR DESCRIPTION
@toastal 

how about this

to update - you remove hashes

```dhall
let upstream =
      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200831/packages.dhall sha256:cdb3529cac2cd8dd780f07c80fd907d5faceae7decfcaa11a12037df68812c83

let overrides = {=}

let additions = {=}

in      upstream
    //  https://raw.githubusercontent.com/srghma/dotfiles/master/spago/packages.dhall
          upstream.(https://raw.githubusercontent.com/srghma/dotfiles/master/spago/upstreamTypeChunk.dhall ) -- notice this space at the end, without it dhall will throw parsing error, yes
    //  overrides
    //  additions
```

the `record.({ xxx : YYY })` is a record projection, you kind of extract fields from bigger record (or abridge fields)