### PR TITLE
ArgonautCore.stringifyWithIndent

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -5,7 +5,7 @@ let overrides =
       { argonaut-core =
               upstream.argonaut-core
           //  { repo = "https://github.com/srghma/purescript-argonaut-core.git"
-              , version = "master"
+              , version = "83a16f6aaf2ca62b9aa07eb155dbdeb561ba0d55"
               }
       , either =
               upstream.either

--- a/src/GraphqlClient/HTTP.purs
+++ b/src/GraphqlClient/HTTP.purs
@@ -84,7 +84,7 @@ printGraphqlError = case _ of
   GraphqlUnexpectedPayloadError error jsonBody -> intercalate "\n"
     [ "Unexpected payload:"
     , "  error = " <> printJsonDecodeError error
-    , "  body = " <> ArgonautCore.stringifyWithSpace 2 jsonBody
+    , "  body = " <> ArgonautCore.stringifyWithIndent 2 jsonBody
     ]
   GraphqlUserError errorsArray possiblyParsedData ->
     let errorsArray' = errorsArray <#> unwrap <#> _.message <#> ("  " <> _)
@@ -155,7 +155,7 @@ graphqlRequestImpl url headers query decoder = Transformers.runExceptT do
   jsonBody <- case result of
     Left error -> Transformers.throwError $ GraphqlAffjaxError error
     Right response -> pure response.body
-  -- | traceWithoutInspectM $ "[graphqlRequestImpl] jsonBody " <> ArgonautCore.stringifyWithSpace 2 jsonBody -- TODO: move outside
+  -- | traceWithoutInspectM $ "[graphqlRequestImpl] jsonBody " <> ArgonautCore.stringifyWithIndent 2 jsonBody -- TODO: move outside
   except $ tryDecodeGraphqlResponse decoder jsonBody
 
 -- graphqlRequestImplWithTrace


### PR DESCRIPTION
This is why you need hash pins and shouldn't pin to `master`. I just copied the `(packages.dhall).overrides`, ran `spago build` and got a failure because the latest commit to Argonaut.Core doesn't match what's in this repo which says grab from `master`. I know this a part of your [PR](https://github.com/purescript-graphql-client/purescript-graphql-client/pull/13), but the main branch is currently in a failing-on-fresh-install state irrespective of the discussion in that thread.

Why didn't the builds fail though? Is Travis caching an old copy of Argonaut.Core's `master`?

(currently I'm overriding locally to this PR branch)